### PR TITLE
Init Logger fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abci"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Adrian Brink <adrian@brink-holdings.com>", "Jackson Lewis <st.japa6@gmail.com>", "Dave Bryson", "Tomas Tauber"]
 license = "MIT/Apache-2.0"
 description = "Tendermint ABCI server for Rust"

--- a/examples/counter_app.rs
+++ b/examples/counter_app.rs
@@ -1,8 +1,10 @@
 extern crate abci;
 extern crate byteorder;
+extern crate env_logger;
 
 use abci::*;
 use byteorder::{BigEndian, ByteOrder};
+use env_logger::Env;
 
 // Simple counter application.  Its only state is a u64 count
 // We use BigEndian to serialize the data across transactions calls
@@ -69,5 +71,6 @@ impl abci::Application for CounterApp {
 
 fn main() {
     // Run on localhost using default Tendermint port
+    env_logger::from_env(Env::default().default_filter_or("info")).init();
     abci::run_local(CounterApp::new());
 }

--- a/examples/empty_app.rs
+++ b/examples/empty_app.rs
@@ -1,4 +1,7 @@
 extern crate abci;
+extern crate env_logger;
+
+use env_logger::Env;
 
 // Simple example that responds with defaults to Tendermint
 struct EmptyApp;
@@ -10,5 +13,6 @@ fn main() {
     // Use default local addr and Tendermint ABCI port
     let addr = "127.0.0.1:26658".parse().unwrap();
     // Fire it up!
+    env_logger::from_env(Env::default().default_filter_or("info")).init();
     abci::run(addr, EmptyApp);
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -15,7 +15,9 @@ pub fn serve<A>(app: A, addr: SocketAddr) -> io::Result<()>
 where
     A: Application + 'static + Send + Sync,
 {
-    env_logger::from_env(Env::default().default_filter_or("info")).init();
+    env_logger::from_env(Env::default().default_filter_or("info"))
+        .try_init()
+        .ok();
     let listener = TcpListener::bind(addr).unwrap();
 
     // Wrap the app atomically and clone for each connection.


### PR DESCRIPTION
- Changed to try_init, if init twice program panics
- Added into example apps the init of the logger

closes #54 

Signed-off-by: Marko Baricevic <marbar3778@yahoo.com>