### PR TITLE
ci: move part of ci to github actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,34 +9,6 @@ jobs:
       - restore_cache:
           key: project-cache
       - run:
-          name: Check formatting
-          command: |
-            rustup component add rustfmt-preview
-            rustfmt --version
-            cargo fmt -- --check --color=auto
-      - run:
-          name: Check Linting
-          command: |
-            rustup component add clippy
-            cargo clippy
-      - run:
-          name: Nightly Build
-          command: |
-            rustup toolchain install nightly
-            rustup run nightly rustc --version --verbose
-            rustup run nightly cargo --version --verbose
-            rustup run nightly cargo build
-      - run:
-          name: Stable Build
-          command: |
-            rustup toolchain install stable
-            rustup run stable rustc --version --verbose
-            rustup run stable cargo --version --verbose
-            rustup run stable cargo build
-      - run:
-          name: Test
-          command: rustup run stable cargo test
-      - run:
           name: Publish Crate
           command: |
             if [ $CIRCLE_BRANCH == master ]; then cargo login $CARGO_TOKEN && cargo package --allow-dirty && cargo publish --allow-dirty; fi

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,54 @@
+name: Rust
+on: [pull_request]
+jobs:
+  cleanup-runs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: rokroskar/workflow-run-cleanup-action@master
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
+
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+          override: true
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features
+
+  test-stable:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --workspace --all-targets
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features --no-fail-fast


### PR DESCRIPTION
closes #127 

moved all ci to GitHub actions except deployment to crates.io

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Bump Tendermint & ABCI version in README.md if version was updated


______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
