### PR TITLE
Fix decoding unterminated varint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ include = ["src/**/*", "Cargo.toml"]
 bytes = "0.4"
 protobuf = "= 2.15.1"
 byteorder = "1.3.4"
-integer-encoding = "1.1.5"
+integer-encoding = { git = "https://github.com/yihuang/integer-encoding-rs.git", branch = "issue9" }
 log = "0.4.8"
 env_logger = "0.7.1"
 tokio = { version = "0.1", default-features = false, features = ["codec", "io", "tcp", "rt-full"] }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 
 use bytes::{BufMut, BytesMut};
 use integer_encoding::VarInt;
-use protobuf::Message;
+use protobuf::{error::WireError, Message, ProtobufError};
 use tokio::codec::{Decoder, Encoder};
 
 use crate::messages::abci::*;
@@ -25,7 +25,8 @@ impl Decoder for ABCICodec {
         if length == 0 {
             return Ok(None);
         }
-        let varint: (i64, usize) = i64::decode_var(&buf[..]);
+        let varint: (i64, usize) =
+            i64::decode_var(&buf[..]).ok_or(ProtobufError::WireError(WireError::UnexpectedEof))?;
         if varint.0 as usize + varint.1 > length {
             return Ok(None);
         }


### PR DESCRIPTION
The prefixing varint encoded length, there's no check on the MSB bit of last byte.
After the pr to integer-encoding-rs merged and released, change the dependency.